### PR TITLE
Fix passing the loglevel to GrayLog

### DIFF
--- a/classes/Handlers/GraylogHandler.php
+++ b/classes/Handlers/GraylogHandler.php
@@ -5,6 +5,7 @@ namespace Grav\Plugin\LoggerChannels\Handlers;
 use Monolog\Handler\GelfHandler;
 use Monolog\Handler\NullHandler;
 use Monolog\Formatter\GelfMessageFormatter;
+use Monolog\Logger;
 use Gelf\Publisher;
 use Gelf\Transport\TcpTransport;
 use Gelf\Transport\UdpTransport;
@@ -64,7 +65,7 @@ class GraylogHandler extends BaseHandler
         $formatter->setExtraFields($extraFields);
 
         // Setup handler
-        $this->handler = new GelfHandler($publisher, $options['level']);
+        $this->handler = new GelfHandler($publisher, Logger::toMonologLevel($options['level'] ?? 'INFO'));
         $this->handler->setFormatter($formatter);
     }
 }


### PR DESCRIPTION
GelfHandler expects an int (a Logger-defined level)

Note that blueprints' _defaults_ does not ensure the `level` key actually exists